### PR TITLE
Extra validation for DE/COCs and DE/OUs

### DIFF
--- a/server.R
+++ b/server.R
@@ -126,6 +126,14 @@ shinyServer(function(input, output, session) {
         
         d <- validateSiteData(d)
         
+        incProgress(0.1, detail = ("Checking data element/ disaggregations"))
+        
+        d <-validateDataElementDisaggs(d)
+        
+        incProgress(0.1, detail = ("Checking data element/ organisation units"))
+        
+        d <- validateDataElementOrgunits(d)
+        
         incProgress(0.1, detail = ("Processing mechanisms"))
         
         d <- adornMechanisms(d)

--- a/utils.R
+++ b/utils.R
@@ -47,9 +47,7 @@ validateDataElementOrgunits<-function(d) {
     d$datim$dataelement_disagg_check<-de_check
     d$info$warningMsg<-append(messages,d$info$warningMsg)
     d$info$had_error<-TRUE
-  } else {
-    messages<-append("Data element/orgunit associations are valid.", messages)
-  }
+  } 
   
   d
 }

--- a/utils.R
+++ b/utils.R
@@ -63,7 +63,7 @@ validateDataElementDisaggs<-function(d){
                       "value")
   datasets <- c("nIHNMxuPUOR", "sBv1dj90IX6")
   
-  des_disagg_check<-datimvalidation::checkDataElementDisaggValidity(data=d,
+  des_disagg_check<-datimvalidation::checkDataElementDisaggValidity(data=vr_data,
                                                                     datasets=datasets)
   
   

--- a/utils.R
+++ b/utils.R
@@ -244,7 +244,8 @@ modalitySummaryChart <- function(d) {
     dplyr::mutate(Age=factor(as.character(Age),levels=age_order))
   
   ggplot(foo, aes(x=Age,y=value, fill=hts_sex)) + 
-    geom_bar(stat = "identity") + 
+    geom_bar(stat = "identity") +
+    scale_y_continuous(labels = scales::comma) + 
     facet_wrap(~hts_modality) + 
     theme() +
     scale_fill_manual(values = c("#548dc0", "#59BFB3")) +

--- a/utils.R
+++ b/utils.R
@@ -20,6 +20,66 @@ DHISLogin <- function(baseurl, username, password) {
   }
 }
 
+validateDataElementOrgunits<-function(d) {
+  
+  datasets <- c("nIHNMxuPUOR", "sBv1dj90IX6")
+  vr_data <- d$datim$site_data
+  names(vr_data) <- c("dataElement",
+                      "period",
+                      "orgUnit",
+                      "categoryOptionCombo",
+                      "attributeOptionCombo",
+                      "value")
+  
+  de_check <-
+    datimvalidation::checkDataElementOrgunitValidity(
+      data = vr_data,
+      datasets = ds,
+      organisationUnit = d$info$datapack_uid
+    ) 
+  
+  if (inherits(de_check, "data.frame")) {
+    messages<-append(paste(
+      NROW(de_check),
+      "invalid data element/orgunit associations found!"
+    ), messages)
+    
+    d$datim$dataelement_disagg_check<-de_check
+    d$info$warningMsg<-append(messages,d$info$warningMsg)
+    d$info$had_error<-TRUE
+  } else {
+    messages<-append("Data element/orgunit associations are valid.", messages)
+  }
+  
+  d
+}
+
+validateDataElementDisaggs<-function(d){
+  #Validation rule checking
+  vr_data <- d$datim$site_data
+  names(vr_data) <- c("dataElement",
+                      "period",
+                      "orgUnit",
+                      "categoryOptionCombo",
+                      "attributeOptionCombo",
+                      "value")
+  datasets <- c("nIHNMxuPUOR", "sBv1dj90IX6")
+  
+  des_disagg_check<-datimvalidation::checkDataElementDisaggValidity(data=d,
+                                                                    datasets=datasets)
+  
+  
+  if (inherits(des_disagg_check, "data.frame")) {
+    
+    d$datim$des_disagg_check<-des_disagg_check
+    msg <- "ERROR!: Invalid data element / disagg combinations found!"
+    d$info$warningMsg<-append(msg,d$info$warningMsg)
+    d$info$had_error<-TRUE
+  }
+  
+  d
+}
+
 validateSiteData <- function(d) {
   #Validation rule checking
   vr_data <- d$datim$site_data


### PR DESCRIPTION
Add additional validation per the standard DATIM import method for validating data element/disaggs and data element /orgunits.